### PR TITLE
Add a chat command to execute a chat command multiple times

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -36,6 +36,26 @@ minetest.register_chatcommand("run_as", {
 	end,
 })
 
+minetest.register_chatcommand("repeat", {
+	params = "<repetitions> /<command>",
+	description = "Run a chatcommand multiple times",
+	func = function(name, param)
+		local repetitions, msg = param:match"^([0-9]+) *(/.*)"
+		if not repetitions then
+			return false, "Invalid arguments (see /help run_as)."
+		end
+		repetitions = tonumber(repetitions)
+		if repetitions > 5
+		and not minetest.check_player_privs(name, "server") then
+			return false,
+				"More than 5 repetitions require the server privilege."
+		end
+		for _ = 1, repetitions do
+			execute_chatcommand(name, msg)
+		end
+	end,
+})
+
 minetest.register_chatcommand("grantme", {
 	params = "<privilege>|all",
 	description = "Give privilege to yourself",


### PR DESCRIPTION
I thought about adding an argument to the we_undo mod's `/undo` and `/redo` chat commands to specify how many of the changes should be undone/redone and noticed that a generic `repeat` chat command is also possible, which can be useful for chat commands other than `/undo` and `/redo`, too.